### PR TITLE
Fix incorrect rating-dist

### DIFF
--- a/goodreads
+++ b/goodreads
@@ -59,7 +59,7 @@ case $arg in
                 curl  -s -X "GET" -d "title=$3" -d "key=$DEVELOPER_KEY" "https://www.goodreads.com/book/title.xml" \
                     | grep "<rating_dist>.*" \
                     | sed "s/<[^>]*>//g" \
-                    | sed "s/\|/:/g" \
+                    | sed "s/|/:/g" \
                     | awk -F ':' '{print "★ ★ ★ ★ ★ : "$2 "\n" "★ ★ ★ ★ ☆ : "$4 "\n" "★ ★ ★ ☆ ☆ : "$6 "\n" "★ ★ ☆ ☆ ☆ : "$8 "\n" "★ ☆ ☆ ☆ ☆ : "$10 "\n\nTotal : " $12}'
                 ;;
 


### PR DESCRIPTION
before:
$ goodreads book --rating-dist "Animal Farm"
★ ★ ★ ★ ★ :
★ ★ ★ ★ ☆ : 5
★ ★ ★ ☆ ☆ :
★ ★ ☆ ☆ ☆ : 4
★ ☆ ☆ ☆ ☆ : 2

Total : 0

after:
$ goodreads book --rating-dist "Animal Farm"
★ ★ ★ ★ ★ : 745260
★ ★ ★ ★ ☆ : 774734
★ ★ ★ ☆ ☆ : 466907
★ ★ ☆ ☆ ☆ : 143818
★ ☆ ☆ ☆ ☆ : 71574

Total : 2202293